### PR TITLE
57 task 030a crear endpoint get apipublicavailabilitybusinessid para disponibilidad pública

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -15,6 +15,7 @@ import { BrandModule } from './brand/brand.module';
 import { ScheduleModule } from './schedule/schedule.module';
 import { AppointmentsModule } from './appointments/appointments.module';
 import { ClientModule } from './client/client.module';
+import { PublicAvailabilityModule } from './public-availability/public-availability.module';
 
 @Module({
   imports: [
@@ -32,6 +33,7 @@ import { ClientModule } from './client/client.module';
     FilesModule,
     AppointmentsModule,
     ClientModule,
+    PublicAvailabilityModule,
   ],
   controllers: [],
   providers: [

--- a/backend/src/public-availability/dto/public-availability.dto.ts
+++ b/backend/src/public-availability/dto/public-availability.dto.ts
@@ -1,0 +1,25 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsDateString, IsNotEmpty, IsNumber, IsOptional, Min, Max } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class PublicAvailableTimeSlotsDto {
+  @ApiProperty({ 
+    example: '2024-08-20', 
+    description: 'Fecha para consultar disponibilidad (YYYY-MM-DD)' 
+  })
+  @IsDateString()
+  @IsNotEmpty()
+  date: string;
+
+  @ApiPropertyOptional({ 
+    example: 30, 
+    description: 'Duración deseada en minutos',
+    type: Number
+  })
+  @Type(() => Number) // Transformar string a número
+  @IsNumber()
+  @Min(15)
+  @Max(480)
+  @IsOptional()
+  duration?: number;
+}

--- a/backend/src/public-availability/public-availability.controller.ts
+++ b/backend/src/public-availability/public-availability.controller.ts
@@ -3,81 +3,82 @@ import { ApiTags, ApiOperation, ApiResponse, ApiParam, ApiQuery } from '@nestjs/
 import { AppointmentsService } from '../appointments/appointments.service';
 import { BaseResponseDto } from '../common/dto';
 import { Public } from '../common/decorators';
-import { AvailableTimeSlotsDto, TimeSlotDto } from '../appointments/dto/appointment.dto';
+import { TimeSlotDto } from '../appointments/dto/appointment.dto';
+import { PublicAvailableTimeSlotsDto } from './dto/public-availability.dto';
 
 @ApiTags('Public Availability')
 @Controller('public/availability')
 @Public() // Todo el controller es público
 export class PublicAvailabilityController {
-  constructor(private readonly appointmentsService: AppointmentsService) {}
+    constructor(private readonly appointmentsService: AppointmentsService) { }
 
-  @Get(':businessId')
-  @ApiOperation({
-    summary: 'Obtener slots de tiempo disponibles públicamente',
-    description: 'Retorna los horarios disponibles para un negocio específico sin requerir autenticación. Ideal para que clientes puedan ver disponibilidad antes de registrarse.'
-  })
-  @ApiParam({
-    name: 'businessId',
-    required: true,
-    description: 'ID del negocio para consultar disponibilidad',
-    example: 123
-  })
-  @ApiQuery({ 
-    name: 'date', 
-    required: true, 
-    description: 'Fecha para consultar disponibilidad (YYYY-MM-DD)',
-    example: '2024-08-20'
-  })
-  @ApiQuery({ 
-    name: 'duration', 
-    required: false, 
-    description: 'Duración deseada en minutos',
-    example: 30
-  })
-  @ApiResponse({
-    status: 200,
-    description: 'Horarios disponibles obtenidos exitosamente',
-    type: BaseResponseDto,
-    schema: {
-      example: {
-        success: true,
-        message: "Horarios disponibles obtenidos exitosamente",
-        data: [
-          {
-            time: "09:00",
-            available: true
-          },
-          {
-            time: "09:30",
-            available: false,
-            reason: "Horario ocupado"
-          },
-          {
-            time: "10:00",
-            available: true
-          }
-        ]
-      }
+    @Get(':brandId')
+    @ApiOperation({
+        summary: 'Obtener slots de tiempo disponibles públicamente',
+        description: 'Retorna los horarios disponibles para una marca específica sin requerir autenticación. Ideal para que clientes puedan ver disponibilidad antes de registrarse.'
+    })
+    @ApiParam({
+        name: 'brandId',
+        required: true,
+        description: 'ID de la marca para consultar disponibilidad',
+        example: 123
+    })
+    @ApiQuery({
+        name: 'date',
+        required: true,
+        description: 'Fecha para consultar disponibilidad (YYYY-MM-DD)',
+        example: '2024-08-20'
+    })
+    @ApiQuery({
+        name: 'duration',
+        required: false,
+        description: 'Duración deseada en minutos',
+        example: 30
+    })
+    @ApiResponse({
+        status: 200,
+        description: 'Horarios disponibles obtenidos exitosamente',
+        type: BaseResponseDto,
+        schema: {
+            example: {
+                success: true,
+                message: "Horarios disponibles obtenidos exitosamente",
+                data: [
+                    {
+                        time: "09:00",
+                        available: true
+                    },
+                    {
+                        time: "09:30",
+                        available: false,
+                        reason: "Horario ocupado"
+                    },
+                    {
+                        time: "10:00",
+                        available: true
+                    }
+                ]
+            }
+        }
+    })
+    @ApiResponse({
+        status: 400,
+        description: 'Parámetros inválidos'
+    })
+    @ApiResponse({
+        status: 404,
+        description: 'Negocio no encontrado'
+    })
+    async getPublicAvailableTimeSlots(
+        @Param('brandId') brandId: string,
+        @Query(ValidationPipe) query: PublicAvailableTimeSlotsDto
+    ): Promise<BaseResponseDto<TimeSlotDto[]>> {
+        // El parámetro ya viene como brandId, directamente lo convertimos
+        const parsedBrandId = parseInt(brandId);
+
+        return this.appointmentsService.getAvailableTimeSlots(
+            parsedBrandId,
+            query
+        );
     }
-  })
-  @ApiResponse({
-    status: 400,
-    description: 'Parámetros inválidos'
-  })
-  @ApiResponse({
-    status: 404,
-    description: 'Negocio no encontrado'
-  })
-  async getPublicAvailableTimeSlots(
-    @Param('businessId') businessId: string,
-    @Query(ValidationPipe) query: AvailableTimeSlotsDto
-  ): Promise<BaseResponseDto<TimeSlotDto[]>> {
-    // Mapear businessId a brandId (son equivalentes en el sistema)
-    const brandId = parseInt(businessId);
-    
-    return this.appointmentsService.getAvailableTimeSlots(
-      brandId,
-      query
-    );
-  }
 }

--- a/backend/src/public-availability/public-availability.controller.ts
+++ b/backend/src/public-availability/public-availability.controller.ts
@@ -1,0 +1,83 @@
+import { Controller, Get, Param, Query, ValidationPipe } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse, ApiParam, ApiQuery } from '@nestjs/swagger';
+import { AppointmentsService } from '../appointments/appointments.service';
+import { BaseResponseDto } from '../common/dto';
+import { Public } from '../common/decorators';
+import { AvailableTimeSlotsDto, TimeSlotDto } from '../appointments/dto/appointment.dto';
+
+@ApiTags('Public Availability')
+@Controller('public/availability')
+@Public() // Todo el controller es público
+export class PublicAvailabilityController {
+  constructor(private readonly appointmentsService: AppointmentsService) {}
+
+  @Get(':businessId')
+  @ApiOperation({
+    summary: 'Obtener slots de tiempo disponibles públicamente',
+    description: 'Retorna los horarios disponibles para un negocio específico sin requerir autenticación. Ideal para que clientes puedan ver disponibilidad antes de registrarse.'
+  })
+  @ApiParam({
+    name: 'businessId',
+    required: true,
+    description: 'ID del negocio para consultar disponibilidad',
+    example: 123
+  })
+  @ApiQuery({ 
+    name: 'date', 
+    required: true, 
+    description: 'Fecha para consultar disponibilidad (YYYY-MM-DD)',
+    example: '2024-08-20'
+  })
+  @ApiQuery({ 
+    name: 'duration', 
+    required: false, 
+    description: 'Duración deseada en minutos',
+    example: 30
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Horarios disponibles obtenidos exitosamente',
+    type: BaseResponseDto,
+    schema: {
+      example: {
+        success: true,
+        message: "Horarios disponibles obtenidos exitosamente",
+        data: [
+          {
+            time: "09:00",
+            available: true
+          },
+          {
+            time: "09:30",
+            available: false,
+            reason: "Horario ocupado"
+          },
+          {
+            time: "10:00",
+            available: true
+          }
+        ]
+      }
+    }
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Parámetros inválidos'
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Negocio no encontrado'
+  })
+  async getPublicAvailableTimeSlots(
+    @Param('businessId') businessId: string,
+    @Query(ValidationPipe) query: AvailableTimeSlotsDto
+  ): Promise<BaseResponseDto<TimeSlotDto[]>> {
+    // Mapear businessId a brandId (son equivalentes en el sistema)
+    const brandId = parseInt(businessId);
+    
+    return this.appointmentsService.getAvailableTimeSlots(
+      brandId,
+      query
+    );
+  }
+}

--- a/backend/src/public-availability/public-availability.module.ts
+++ b/backend/src/public-availability/public-availability.module.ts
@@ -3,7 +3,7 @@ import { PublicAvailabilityController } from './public-availability.controller';
 import { AppointmentsModule } from '../appointments/appointments.module';
 
 @Module({
-  imports: [AppointmentsModule],
-  controllers: [PublicAvailabilityController],
+    imports: [AppointmentsModule],
+    controllers: [PublicAvailabilityController],
 })
-export class PublicAvailabilityModule {}
+export class PublicAvailabilityModule { }

--- a/backend/src/public-availability/public-availability.module.ts
+++ b/backend/src/public-availability/public-availability.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { PublicAvailabilityController } from './public-availability.controller';
+import { AppointmentsModule } from '../appointments/appointments.module';
+
+@Module({
+  imports: [AppointmentsModule],
+  controllers: [PublicAvailabilityController],
+})
+export class PublicAvailabilityModule {}


### PR DESCRIPTION
## 🎯 **Overview**
Implements a new public endpoint `GET /api/public/availability/:brandId` that allows clients to check available time slots without authentication. This enables potential customers to view appointment availability before registering or logging in.

## 🚀 **Changes Made**

### New Files Added:
- `src/public-availability/public-availability.controller.ts` - Public controller with @Public decorator
- `src/public-availability/public-availability.module.ts` - Module configuration
- `src/public-availability/dto/public-availability.dto.ts` - DTO with proper type transformations

### Modified Files:
- `src/app.module.ts` - Registered new PublicAvailabilityModule

## 🔧 **Technical Implementation**

### Endpoint Details:
- **Route**: `GET /public/availability/:brandId`
- **Authentication**: None (public endpoint using @Public decorator)
- **Parameters**:
  - `brandId` (path) - Brand ID to query availability for
  - `date` (query, required) - Date in YYYY-MM-DD format
  - `duration` (query, optional) - Duration in minutes (15-480, default from brand settings)

### Key Features:
1. **Reuses existing logic**: Leverages `AppointmentsService.getAvailableTimeSlots()`
2. **Proper validation**: Custom DTO with `@Type(() => Number)` for query parameter transformation
3. **Consistent architecture**: Follows established patterns from other controllers
4. **Complete documentation**: Full Swagger/OpenAPI documentation

## 📊 **Response Format**
```json
{
  "success": true,
  "data": [
    {
      "time": "09:00",
      "available": true
    },
    {
      "time": "09:35",
      "available": false,
      "reason": "Horario ocupado"
    }
  ]
}